### PR TITLE
Inherit timestamps

### DIFF
--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -240,6 +240,11 @@ def _clear_html_files(input_path: Path, all_projects: bool) -> None:
     is_flag=True,
     help="Clear all HTML files and force regeneration",
 )
+@click.option(
+    "--inherit-timestamps",
+    is_flag=True,
+    help="Set HTML file timestamps to match source JSONL files",
+)
 def main(
     input_path: Optional[Path],
     output: Optional[Path],
@@ -251,6 +256,7 @@ def main(
     no_cache: bool,
     clear_cache: bool,
     clear_html: bool,
+    inherit_timestamps: bool,
 ) -> None:
     """Convert Claude transcript JSONL files to HTML.
 
@@ -285,7 +291,7 @@ def main(
 
             click.echo(f"Processing all projects in {input_path}...")
             output_path = process_projects_hierarchy(
-                input_path, from_date, to_date, not no_cache
+                input_path, from_date, to_date, not no_cache, inherit_timestamps
             )
 
             # Count processed projects
@@ -335,6 +341,7 @@ def main(
             to_date,
             not no_individual_sessions,
             not no_cache,
+            inherit_timestamps,
         )
         if input_path.is_file():
             click.echo(f"Successfully converted {input_path} to {output_path}")

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -668,8 +668,6 @@ def _get_combined_transcript_link(cache_manager: "CacheManager") -> Optional[str
         return None
 
 
-
-
 def generate_session_html(
     messages: List[TranscriptEntry],
     session_id: str,
@@ -690,15 +688,25 @@ def generate_session_html(
         combined_link = _get_combined_transcript_link(cache_manager)
 
     if not session_messages:
-        return generate_html([], title or f"Session {session_id[:8]}", combined_transcript_link=combined_link)
+        return generate_html(
+            [],
+            title or f"Session {session_id[:8]}",
+            combined_transcript_link=combined_link,
+        )
 
     # Use the existing generate_html function but with filtered messages and combined link
     return generate_html(
-        session_messages, title or f"Session {session_id[:8]}", combined_transcript_link=combined_link
+        session_messages,
+        title or f"Session {session_id[:8]}",
+        combined_transcript_link=combined_link,
     )
 
 
-def generate_html(messages: List[TranscriptEntry], title: Optional[str] = None, combined_transcript_link: Optional[str] = None) -> str:
+def generate_html(
+    messages: List[TranscriptEntry],
+    title: Optional[str] = None,
+    combined_transcript_link: Optional[str] = None,
+) -> str:
     """Generate HTML from transcript messages using Jinja2 templates."""
     if not title:
         title = "Claude Transcript"

--- a/test/test_combined_transcript_link.py
+++ b/test/test_combined_transcript_link.py
@@ -4,8 +4,6 @@ import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
-
 from claude_code_log.cache import CacheManager
 from claude_code_log.renderer import generate_session_html
 


### PR DESCRIPTION
Adds an `inherit-timestamps` option. The idea was to try to create a Mac [Smart Folder](https://support.apple.com/en-bw/guide/mac-help/mchlp2804/mac) over the `session-<id>.html` files so I can leverage Finder as the GUI to review the files. Inspired by [this](https://www.reddit.com/r/mac/comments/1c3ldoi/wheres_my_disk_space_what_is_taking_up_all_the/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) Reddit thread which used a similar trick to identify large folders/files.

Here's how it looks:

<img width="2784" height="3054" alt="image" src="https://github.com/user-attachments/assets/4fb1256f-5a0b-42de-8a4a-32e73a5663b1" />

This works decently well except it seems that certain sessions float to the top. I'm not sure where these come from.. maybe they are forks when the user runs `/clear`? Or when a user resumes a session? I don't know enough about the Claude Code directory structure yet to answer that question so I'm gonna leave this PR open for now