### PR TITLE
Add --inherit-timestamps option (v2)

### DIFF
--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -240,6 +240,11 @@ def _clear_html_files(input_path: Path, all_projects: bool) -> None:
     is_flag=True,
     help="Clear all HTML files and force regeneration",
 )
+@click.option(
+    "--inherit-timestamps",
+    is_flag=True,
+    help="Set file modification times to match session timestamps from cache",
+)
 def main(
     input_path: Optional[Path],
     output: Optional[Path],
@@ -251,6 +256,7 @@ def main(
     no_cache: bool,
     clear_cache: bool,
     clear_html: bool,
+    inherit_timestamps: bool,
 ) -> None:
     """Convert Claude transcript JSONL files to HTML.
 
@@ -285,7 +291,12 @@ def main(
 
             click.echo(f"Processing all projects in {input_path}...")
             output_path = process_projects_hierarchy(
-                input_path, from_date, to_date, not no_cache
+                input_path,
+                from_date,
+                to_date,
+                not no_cache,
+                not no_individual_sessions,
+                inherit_timestamps,
             )
 
             # Count processed projects
@@ -335,6 +346,7 @@ def main(
             to_date,
             not no_individual_sessions,
             not no_cache,
+            inherit_timestamps,
         )
         if input_path.is_file():
             click.echo(f"Successfully converted {input_path} to {output_path}")


### PR DESCRIPTION
Adds an `--inherit-timestamps` option that sets HTML file modification times to match actual session timestamps from cached data.

## What this does

When enabled with `--inherit-timestamps`, session HTML files (`session-<id>.html`) will have their OS-level modification times set to match the `last_timestamp` field from the session cache data. This enables using Mac Smart Folders or file managers to sort sessions by their actual chronological order rather than when the HTML files were generated.

## How it works

- Extracts session timestamps from cache data (`cache/index.json`)
- Converts ISO timestamp strings to Unix timestamps
- Uses `os.utime()` to set file modification times after HTML generation
- Falls back gracefully when cache data is unavailable

## Difference from PR #1

PR #1 attempted a similar feature but had a critical flaw: it used JSONL file modification times instead of actual session timestamps. This approach failed because:

1. **File timestamps ≠ Session timestamps**: JSONL files may be created/modified at different times than when the actual conversation occurred
2. **Inconsistent sorting**: Some sessions would "float to the top" because their file timestamps didn't reflect the conversation chronology
3. **Cache ordering issue**: Session cache data wasn't available when individual files were generated

## What we fixed

1. **Use actual session timestamps**: Extract `last_timestamp` from cached session data instead of file modification times
2. **Fix cache timing**: Move cache update before individual session file generation so timestamp data is available
3. **Robust timestamp parsing**: Handle both 'Z' suffix and timezone-aware ISO format timestamps
4. **Better error handling**: Graceful fallback when timestamps are missing or invalid

This provides accurate chronological sorting that reflects actual conversation times rather than file system artifacts.

🤖 Generated with [Claude Code](https://claude.ai/code)